### PR TITLE
Feature/model

### DIFF
--- a/CodingActivity_TicTacToe_ConsoleGame.Solution/Controller/Controller.cs
+++ b/CodingActivity_TicTacToe_ConsoleGame.Solution/Controller/Controller.cs
@@ -113,11 +113,6 @@ namespace CodingActivity_TicTacToe_ConsoleGame
                 }
 
                 //
-                // Round Complete: Display the results
-                //
-                _gameView.DisplayCurrentGameStatus(_roundNumber, _playerXNumberOfWins, _playerONumberOfWins, _numberOfCatsGames);
-
-                //
                 // Confirm no major user errors
                 //
                 if (_gameView.CurrentViewState != ConsoleView.ViewState.PlayerUsedMaxAttempts ||
@@ -169,16 +164,19 @@ namespace CodingActivity_TicTacToe_ConsoleGame
 
                         case Gameboard.GameboardState.PlayerXWin:
                             _playerXNumberOfWins++;
+                            _gameView.DisplayCurrentGameStatus(_roundNumber, _playerXNumberOfWins, _playerONumberOfWins, _numberOfCatsGames);
                             _playingRound = false;
                             break;
 
                         case Gameboard.GameboardState.PlayerOWin:
                             _playerONumberOfWins++;
+                            _gameView.DisplayCurrentGameStatus(_roundNumber, _playerXNumberOfWins, _playerONumberOfWins, _numberOfCatsGames);
                             _playingRound = false;
                             break;
 
                         case Gameboard.GameboardState.CatsGame:
                             _numberOfCatsGames++;
+                            _gameView.DisplayCurrentGameStatus(_roundNumber, _playerXNumberOfWins, _playerONumberOfWins, _numberOfCatsGames);
                             _playingRound = false;
                             break;
 
@@ -267,7 +265,7 @@ namespace CodingActivity_TicTacToe_ConsoleGame
                         // placeholder code
                         break;
                     case MainMenuOption.ViewCurrentGameResults:
-                        // placeholder code
+                        _gameView.DisplayCurrentGameStatus(_roundNumber, _playerXNumberOfWins, _playerONumberOfWins, _numberOfCatsGames);
                         break;
                     case MainMenuOption.ViewPastGameResults:
                         // placeholder code

--- a/CodingActivity_TicTacToe_ConsoleGame.Solution/Model/Gameboard.cs
+++ b/CodingActivity_TicTacToe_ConsoleGame.Solution/Model/Gameboard.cs
@@ -27,12 +27,12 @@ namespace CodingActivity_TicTacToe_ConsoleGame
             PlayerOTurn,
             PlayerXWin,
             PlayerOWin,
-            CatsGame
+            CatsGame,
         }
 
         private enum PositionMovement
         {
-            Up,
+            None,
             UpRight,
             Right,
             DownRight,
@@ -239,15 +239,15 @@ namespace CodingActivity_TicTacToe_ConsoleGame
         private bool FourInARow(PlayerPiece playerPieceToCheck, GameboardPosition gameboardPosition)
         {
             //Define linear checks for a win
-            PositionMovement[] upDown = new PositionMovement[] { PositionMovement.Up, PositionMovement.Down };
+            PositionMovement[] down = new PositionMovement[] { PositionMovement.Down, PositionMovement.None };
             PositionMovement[] leftRight = new PositionMovement[] { PositionMovement.Left, PositionMovement.Right };
             PositionMovement[] UrightDleft = new PositionMovement[] { PositionMovement.UpRight, PositionMovement.DownLeft };
             PositionMovement[] UleftDright = new PositionMovement[] { PositionMovement.UpLeft, PositionMovement.DownRight };
 
             int counter = 0;
 
-            //Check up and down
-            counter = ConsecutivePieces(playerPieceToCheck, gameboardPosition, upDown[0], upDown[1]);
+            //Check down
+            counter = ConsecutivePieces(playerPieceToCheck, gameboardPosition, down[0], down[1]);
 
             if (CheckForFourPieces(counter)) return true;
 
@@ -289,28 +289,34 @@ namespace CodingActivity_TicTacToe_ConsoleGame
             int counter = 1;
 
             //Check consecutive linear pieces in one direction
-            for (int i = 0; i < piecesTocheck; i++)
+            if(movement1 != PositionMovement.None)
             {
-                if (CheckNextPiece(piece, gameboardPosition, movement1, i + 1))
+                for (int i = 0; i < piecesTocheck; i++)
                 {
-                    counter = counter + 1;
-                }
-                else
-                {
-                    break;
+                    if (CheckNextPiece(piece, gameboardPosition, movement1, i + 1))
+                    {
+                        counter = counter + 1;
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
             }
 
             //Check consecutive linear pieces in the other direction
-            for (int i = 0; i < piecesTocheck; i++)
+            if(movement2 != PositionMovement.None)
             {
-                if (CheckNextPiece(piece, gameboardPosition, movement2, i + 1))
+                for (int i = 0; i < piecesTocheck; i++)
                 {
-                    counter = counter + 1;
-                }
-                else
-                {
-                    break;
+                    if (CheckNextPiece(piece, gameboardPosition, movement2, i + 1))
+                    {
+                        counter = counter + 1;
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
             }
 
@@ -339,9 +345,6 @@ namespace CodingActivity_TicTacToe_ConsoleGame
             //Based on the given Movement, set newPosition to the next position in line 
             switch (movement)
             {
-                case PositionMovement.Up:
-                    newPosition = MovePositionUp(gameboardPosition, numberOfMoves);
-                    break;
                 case PositionMovement.UpRight:
                     newPosition = MovePositionUpRight(gameboardPosition, numberOfMoves);
                     break;
@@ -385,20 +388,6 @@ namespace CodingActivity_TicTacToe_ConsoleGame
                 return false;
             }
         }
-
-        /// <summary>
-        /// Move position up one row
-        /// </summary>
-        /// <param name="gameboardPosition"></param>
-        /// <param name="number"></param>
-        /// <returns></returns>
-        private GameboardPosition MovePositionUp(GameboardPosition gameboardPosition, int number)
-        {
-            gameboardPosition.Row = gameboardPosition.Row - number;
-
-            return gameboardPosition;
-        }
-
         /// <summary>
         /// Move position up one row, one column to the right
         /// </summary>

--- a/CodingActivity_TicTacToe_ConsoleGame.Solution/Model/Gameboard.cs
+++ b/CodingActivity_TicTacToe_ConsoleGame.Solution/Model/Gameboard.cs
@@ -27,7 +27,7 @@ namespace CodingActivity_TicTacToe_ConsoleGame
             PlayerOTurn,
             PlayerXWin,
             PlayerOWin,
-            CatsGame,
+            CatsGame
         }
 
         private enum PositionMovement

--- a/CodingActivity_TicTacToe_ConsoleGame.Solution/View/ConsoleView.cs
+++ b/CodingActivity_TicTacToe_ConsoleGame.Solution/View/ConsoleView.cs
@@ -87,13 +87,13 @@ namespace CodingActivity_TicTacToe_ConsoleGame
         /// <summary>
         /// display the Continue prompt
         /// </summary>
-        public void DisplayContinuePrompt()
+        public void DisplayContinuePrompt(string message = "Press any key to continue.")
         {
             Console.CursorVisible = false;
 
             Console.WriteLine();
 
-            ConsoleUtil.DisplayMessage("Press any key to continue.");
+            ConsoleUtil.DisplayMessage(message);
             ConsoleKeyInfo response = Console.ReadKey();
 
             Console.WriteLine();
@@ -208,16 +208,24 @@ namespace CodingActivity_TicTacToe_ConsoleGame
             ConsoleUtil.HeaderText = "Current Game Status";
             ConsoleUtil.DisplayReset();
 
-            double playerXPercentageWins = (double)playerXWins / roundsPlayed;
-            double playerOPercentageWins = (double)playerOWins / roundsPlayed;
-            double percentageOfCatsGames = (double)catsGames / roundsPlayed;
+            double playerXPercentageWins = 0;
+            double playerOPercentageWins = 0;
+            double percentageOfCatsGames = 0;
+
+            if (roundsPlayed > 0)
+            {
+                playerXPercentageWins = (double)playerXWins / roundsPlayed;
+                playerOPercentageWins = (double)playerOWins / roundsPlayed;
+                percentageOfCatsGames = (double)catsGames / roundsPlayed;
+            }
+        
 
             ConsoleUtil.DisplayMessage("Rounds Played: " + roundsPlayed);
             ConsoleUtil.DisplayMessage("Rounds for Player X: " + playerXWins + " - " + String.Format("{0:P2}", playerXPercentageWins));
             ConsoleUtil.DisplayMessage("Rounds for Player O: " + playerOWins + " - " + String.Format("{0:P2}", playerOPercentageWins));
             ConsoleUtil.DisplayMessage("Cat's Games: " + catsGames + " - " + String.Format("{0:P2}", percentageOfCatsGames));
 
-            DisplayContinuePrompt();
+            DisplayContinuePrompt("Press any key to return to the Main Menu.");
         }
 
         public bool DisplayNewRoundPrompt()


### PR DESCRIPTION
Win check refactored to no longer check above the last placed piece.
Game Status screen only displays after a game or when selected from the Main Menu.
Game Status screen displays a 0% for the percentages if no round is played (instead of '0 - NaN').
DisplayContinuePrompt can take an optional message to display.