### PR TITLE
Exit Feature

### DIFF
--- a/CodingActivity_TicTacToe_ConsoleGame.Solution/Controller/Controller.cs
+++ b/CodingActivity_TicTacToe_ConsoleGame.Solution/Controller/Controller.cs
@@ -181,19 +181,27 @@ namespace CodingActivity_TicTacToe_ConsoleGame
         /// <param name="currentPlayerPiece">identify as either the X or O player</param>
         private void ManagePlayerTurn(Gameboard.PlayerPiece currentPlayerPiece)
         {
-            GameboardPosition gameboardPosition = _gameView.GetPlayerPositionChoice();
+            int column = _gameView.PlayerCoordinateChoice();
+
+            if(column == _gameboard.EXIT_ROUND_CODE)
+            {
+                _numberOfCatsGames++;
+                _playingRound = false;
+                _gameView.DisplayCurrentGameStatus(_roundNumber, _playerXNumberOfWins, _playerONumberOfWins, _numberOfCatsGames);
+                return;
+            }
 
             //
             // player chose an open position on the game board, add it to the game board
             //
-            if (_gameboard.GameboardColumnAvailable(gameboardPosition.Column - 1))
+            if (_gameboard.GameboardColumnAvailable(column - 1))
             {
-                _gameboard.SetPlayerPiece(gameboardPosition, currentPlayerPiece);
+                _gameboard.SetPlayerPiece(column, currentPlayerPiece);
 
                 //
                 // Evaluate and update the current game board state
                 //
-                _gameboard.UpdateGameboardState(gameboardPosition.Column - 1);
+                _gameboard.UpdateGameboardState(column - 1);
             }
         }
 
@@ -265,6 +273,14 @@ namespace CodingActivity_TicTacToe_ConsoleGame
                 //Handle the key pressed and update the current index
                 index = HandleKeyMovement(selection, index, playerOptions.Length);
 
+                //Check for Exit Code
+                if(index == _gameboard.EXIT_ROUND_CODE)
+                {
+                    _roundNumber--;
+                    _playingRound = false;
+                    return;
+                }
+
                 //Display the list of options after the movement
                 _gameView.DisplayFirstPlayerOptions(index, playerOptions);
             }
@@ -296,6 +312,10 @@ namespace CodingActivity_TicTacToe_ConsoleGame
             {
                 index--;
                 if (index < 0) index = lengthOfOptions - 1;
+            }
+            else if(i.Key == ConsoleKey.Escape)
+            {
+                index = _gameboard.EXIT_ROUND_CODE;
             }
 
             return index;

--- a/CodingActivity_TicTacToe_ConsoleGame.Solution/Model/Gameboard.cs
+++ b/CodingActivity_TicTacToe_ConsoleGame.Solution/Model/Gameboard.cs
@@ -58,6 +58,8 @@ namespace CodingActivity_TicTacToe_ConsoleGame
 
         private GameboardState _currentRoundState;
 
+        private const int _exit_round_code = 201;
+
         #endregion
 
         #region PROPERTIES
@@ -92,6 +94,11 @@ namespace CodingActivity_TicTacToe_ConsoleGame
         {
             get { return _currentRoundState; }
             set { _currentRoundState = value; }
+        }
+
+        public int EXIT_ROUND_CODE
+        {
+            get { return _exit_round_code; }
         }
         #endregion
 
@@ -479,13 +486,13 @@ namespace CodingActivity_TicTacToe_ConsoleGame
         /// </summary>
         /// <param name="gameboardPosition"></param>
         /// <param name="PlayerPiece"></param>
-        public void SetPlayerPiece(GameboardPosition gameboardPosition, PlayerPiece PlayerPiece)
+        public void SetPlayerPiece(int column, PlayerPiece PlayerPiece)
         {
             //
             // Row and column value adjusted to match array structure
             // Note: gameboardPosition converted to array index by subtracting 1
             //
-            _positionState[NextAvailableRowInColumn(gameboardPosition.Column - 1), gameboardPosition.Column - 1] = PlayerPiece;
+            _positionState[NextAvailableRowInColumn(column - 1), column - 1] = PlayerPiece;
 
             //
             // Change game board state to next player

--- a/CodingActivity_TicTacToe_ConsoleGame.Solution/View/ConsoleView.cs
+++ b/CodingActivity_TicTacToe_ConsoleGame.Solution/View/ConsoleView.cs
@@ -362,31 +362,11 @@ namespace CodingActivity_TicTacToe_ConsoleGame
         }
 
         /// <summary>
-        /// Get a player's position choice within the correct range of the array
-        /// Note: The ConsoleView is allowed access to the GameboardPosition struct.
-        /// </summary>
-        /// <returns>GameboardPosition</returns>
-        public GameboardPosition GetPlayerPositionChoice()
-        {
-            //
-            // Initialize gameboardPosition with -1 values
-            //
-            GameboardPosition gameboardPosition = new GameboardPosition(-1, -1);
-
-            //
-            // Get column number.
-            //
-            gameboardPosition.Column = PlayerCoordinateChoice();
-        
-            return gameboardPosition;
-        }
-
-        /// <summary>
         /// Validate the player's coordinate response for integer and range
         /// </summary>
         /// <param name="coordinateType">an integer value within proper range or -1</param>
         /// <returns></returns>
-        private int PlayerCoordinateChoice()
+        public int PlayerCoordinateChoice()
         {
             int playerColChoice = 1;
             int newPlayerPieceLoc = 34;
@@ -444,8 +424,11 @@ namespace CodingActivity_TicTacToe_ConsoleGame
                             } while (!availableColumns.Contains(playerColChoice));
                             break;
                         case ConsoleKey.Enter:
-                                playerConfirm = true; 
+                            playerConfirm = true; 
                             break;
+                        case ConsoleKey.Escape:
+                            playerColChoice = _gameboard.EXIT_ROUND_CODE;
+                            return playerColChoice;
                         default:
                             break;
                     }
@@ -561,7 +544,7 @@ namespace CodingActivity_TicTacToe_ConsoleGame
 
             sb.Clear();
 
-            sb.AppendFormat("Be the first player to connect four of your game pieces in a consecutive line.");
+            sb.AppendFormat("Be the first player to connect four of your game pieces horizontally, vertically, or diagonally.");
             ConsoleUtil.DisplayMessage(sb.ToString());
             Console.WriteLine();
             Console.WriteLine();
@@ -574,12 +557,50 @@ namespace CodingActivity_TicTacToe_ConsoleGame
 
             sb.Clear();
 
-            sb.AppendFormat("Players alternate dropping one of their game piece into a column on the game board." +
-                " The game ends when a player connects four of their pieces horizontally, vertically, or diagonally." +
-                " If all of the positions on the game board are filled, the game ends and it is counted as a tie." +
-                " Once a column is full of pieces, that column will no longer be available to place pieces in." +
-                " The game is played on a 6x7 game board.");
+            sb.AppendFormat("- Players alternate dropping one of their game pieces into a column on the game board");
             ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
+
+            sb.AppendFormat("- The game ends when four of the same pieces are connected horizontally, vertically, or diagonally");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
+
+            sb.AppendFormat("- If all of the positions on the game board are filled, the round is counted as a draw");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
+
+            sb.AppendFormat("- If the game is ended early, the round is counted as a draw");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
+
+            sb.AppendFormat("- If the game is ended while selecting the starting player, the round isn't counted");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            Console.WriteLine();
+            Console.WriteLine();
+
+            sb.Clear();
+
+            sb.AppendFormat("Keyboard Usage:");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            Console.WriteLine();
+
+            sb.Clear();
+
+            sb.AppendFormat("Up & Down arrow keys :       Selecting the First Player to Start");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
+
+            sb.AppendFormat("Left & Right arrow keys :    Selecting a column on the Gameboard to drop a piece");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
+
+            sb.AppendFormat("Enter :                      Submitting your selection");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
+
+            sb.AppendFormat("Escape :                     End the ConnectFour round to return to the Main Menu");
+            ConsoleUtil.DisplayMessage(sb.ToString());
+            sb.Clear();
 
             Console.WriteLine();
 


### PR DESCRIPTION
Players can exit the ConnectFour round with ESC. If ESC is pressed while selecting a player to start, the round isn't counted. If ESC is pressed during a round, the game ends and the round counts as a tie.
Refactored Controller/ConsoleView to pass around a column integer instead of an instance of the GameBoard (which contained a row property that we didn't use in these functions).
Updated the Game Rules screen to format the text and add a Key Usage section.
